### PR TITLE
Bump default Statsite version to 0.7.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-statsite_version: "0.6.5-1"
+statsite_version: "0.7.0-1"
 statsite_data_dir: "/var/lib/statsite"
 
 statsite_log: /var/log/statsite.log


### PR DESCRIPTION
This changeset bumps the version of Statsite installed by default to `v0.7.0`.

See also: https://packagecloud.io/azavea/statsite/packages/ubuntu/trusty/statsite_0.7.0-1_amd64.deb
