### PR TITLE
Build Statsite from source; bump version to 0.7.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .vagrant
+
+examples/roles/azavea.git
+examples/roles/azavea.pip

--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ An Ansible role to install [Statsite](https://github.com/armon/statsite).
 ## Role Variables
 
 - `statsite_version` - Statsite version
+- `statsite_conf_dir` - Statsite configuration directory (default: `/etc/statsite`)
+- `statsite_sink_dir` - Statsite sink collection directory (default: `/usr/libexec/statsite`)
 - `statsite_data_dir` - Home directory for the Statsite system user (default: `/var/lib/statsite`)
 - `statsite_flush_interval` - How often metrics should be flushed to sink in seconds (default: `10`)
+- `statsite_stream_cmd` - Stream command to Statsite sink
 - `statsite_log` - Statsite log path (default: `/var/log/statsite.log`)
 - `statsite_log_rotate_count` - Statsite log rotation count (default: `5`)
 - `statsite_log_rotate_interval` - Statsite log rotation interval (default: `daily`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,10 @@
 ---
-statsite_version: "0.7.0-1"
+statsite_version: "0.7.1"
+statsite_conf_dir: "/etc/statsite"
+statsite_sink_dir: "/usr/libexec/statsite"
 statsite_data_dir: "/var/lib/statsite"
 statsite_flush_interval: 10
+statsite_stream_cmd: "python /usr/libexec/statsite/graphite.py localhost 2003"
 
 statsite_log: /var/log/statsite.log
 statsite_log_rotate_count: 5

--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -3,6 +3,13 @@
 
 VAGRANTFILE_API_VERSION = "2"
 
+# Ensure role dependencies are in place
+if [ "up", "provision" ].include?(ARGV.first) && File.directory?("roles") &&
+  !(File.directory?("roles/azavea.git") || File.symlink?("roles/azavea.git")) ||
+  !(File.directory?("roles/azavea.pip") || File.symlink?("roles/azavea.pip"))
+  system("ansible-galaxy install --force -r roles.txt -p roles")
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/trusty64"
 

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,0 +1,2 @@
+azavea.pip,0.1.1
+azavea.git,0.1.0

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,4 +11,6 @@ galaxy_info:
   categories:
   - system
   - monitoring
-dependencies: []
+dependencies:
+  - { role: "azavea.git" }
+  - { role: "azavea.pip" }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,23 +2,53 @@
 - name: Create service account for Statsite
   user: name=statsite
         system=yes
-        home={{ statsite_data_dir }}
+        home="{{ statsite_data_dir }}"
         shell=/bin/false
         state=present
 
-- name: Configure the PackageCloud APT key
-  apt_key: url=https://packagecloud.io/gpg.key state=present
+- name: Ensure Statsite directories exist
+  file: path="{{ item }}"
+        state=directory
+  with_items:
+    - "{{ statsite_conf_dir }}"
+    - "{{ statsite_sink_dir }}"
 
-- name: Configure the PackageCloud APT repositories
-  apt_repository: repo="deb https://packagecloud.io/azavea/statsite/ubuntu/ {{ ansible_distribution_release }} main"
-                  state=present
+- name: Download Statsite
+  get_url: url="https://github.com/armon/statsite/archive/v{{ statsite_version }}.tar.gz"
+           dest="/usr/local/src/statsite-{{ statsite_version }}.tar.gz"
 
-- name: Install Statsite
-  apt: pkg=statsite={{ statsite_version }} state=present
+- name: Extract Statsite
+  unarchive: src="/usr/local/src/statsite-{{ statsite_version }}.tar.gz"
+             dest="/usr/local/src"
+             copy=no
+
+- name: Install SCons
+  pip: name="SCons"
+       extra_args="--egg"
+       state=present
+
+- name: Build Statsite
+  command: "make"
+  args:
+    chdir: "/usr/local/src/statsite-{{ statsite_version }}"
+    creates: "/usr/local/src/statsite-{{ statsite_version }}/statsite"
+  register: installed_statsite
+
+- name: Copy Statsite executables
+  command: "cp {{ item.src }} {{ item.dest }}"
+  when: installed_statsite|changed
+  with_items:
+    - { src: "/usr/local/src/statsite-{{ statsite_version }}/statsite", dest: "/usr/sbin" }
+    - { src: "/usr/local/src/statsite-{{ statsite_version }}/sinks/cloudwatch.sh", dest: "{{ statsite_sink_dir }}" }
+    - { src: "/usr/local/src/statsite-{{ statsite_version }}/sinks/graphite.py", dest: "{{ statsite_sink_dir }}" }
+    - { src: "/usr/local/src/statsite-{{ statsite_version }}/sinks/influxdb.py", dest: "{{ statsite_sink_dir }}" }
+    - { src: "/usr/local/src/statsite-{{ statsite_version }}/sinks/librato.py", dest: "{{ statsite_sink_dir }}" }
+  notify:
+    - Restart Statsite
 
 - name: Configure Statsite
   template: src=statsite.cfg.j2
-            dest=/etc/statsite/statsite.cfg
+            dest="{{ statsite_conf_dir }}/statsite.cfg"
   notify:
     - Restart Statsite
 

--- a/templates/logrotate_statsite.j2
+++ b/templates/logrotate_statsite.j2
@@ -3,5 +3,8 @@
   {{ statsite_log_rotate_interval }}
   compress
   missingok
+  postrotate
+    restart statsite
+  endscript
   notifempty
 }

--- a/templates/statsite.cfg.j2
+++ b/templates/statsite.cfg.j2
@@ -5,7 +5,7 @@ log_level = INFO
 flush_interval = {{ statsite_flush_interval }}
 timer_eps = 0.01
 set_eps = 0.02
-stream_cmd = python /usr/libexec/statsite/graphite.py localhost 2003
+stream_cmd = {{ statsite_stream_cmd }}
 
 [histogram_api]
 prefix=api


### PR DESCRIPTION
Instead of maintaining Statsite Debian packages, simply build Statsite from source (it only takes a few seconds). In addition, add support for the following configurable sinks:
- InfluxDB
- CloudWatch
- Librato
