### PR TITLE
Add support for custom flush interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ An Ansible role to install [Statsite](https://github.com/armon/statsite).
 
 - `statsite_version` - Statsite version
 - `statsite_data_dir` - Home directory for the Statsite system user (default: `/var/lib/statsite`)
+- `statsite_flush_interval` - How often metrics should be flushed to sink in seconds (default: `10`)
 - `statsite_log` - Statsite log path (default: `/var/log/statsite.log`)
 - `statsite_log_rotate_count` - Statsite log rotation count (default: `5`)
 - `statsite_log_rotate_interval` - Statsite log rotation interval (default: `daily`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 statsite_version: "0.7.0-1"
 statsite_data_dir: "/var/lib/statsite"
+statsite_flush_interval: 10
 
 statsite_log: /var/log/statsite.log
 statsite_log_rotate_count: 5

--- a/templates/statsite.cfg.j2
+++ b/templates/statsite.cfg.j2
@@ -2,7 +2,7 @@
 port = 8125
 udp_port = 8125
 log_level = INFO
-flush_interval = 10
+flush_interval = {{ statsite_flush_interval }}
 timer_eps = 0.01
 set_eps = 0.02
 stream_cmd = python /usr/libexec/statsite/graphite.py localhost 2003


### PR DESCRIPTION
Allow an override of the `flush_interval` Statsite configuration setting.
