### PR TITLE
Make use of YAML role spec format; replace touch usage

### DIFF
--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -7,7 +7,7 @@ VAGRANTFILE_API_VERSION = "2"
 if [ "up", "provision" ].include?(ARGV.first) && File.directory?("roles") &&
   !(File.directory?("roles/azavea.git") || File.symlink?("roles/azavea.git")) ||
   !(File.directory?("roles/azavea.pip") || File.symlink?("roles/azavea.pip"))
-  system("ansible-galaxy install --force -r roles.txt -p roles")
+  system("ansible-galaxy install --force -r roles.yml -p roles")
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,2 +1,0 @@
-azavea.pip,0.1.1
-azavea.git,0.1.0

--- a/examples/roles.yml
+++ b/examples/roles.yml
@@ -1,0 +1,4 @@
+- name: azavea.pip
+  version: 0.1.1
+- name: azavea.git
+  version: 0.1.0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,8 +58,7 @@
     - Restart Statsite
 
 - name: Touch log file if it does not exist
-  command: touch {{ statsite_log }}
-           creates={{ statsite_log }}
+  copy: content="" dest="{{ statsite_log }}" force=no
 
 - name: Set log file permissions
   file: path={{ statsite_log }} owner=statsite group=statsite mode=0644


### PR DESCRIPTION
The is an attempt to silence deprecation warnings in Ansible 2.0. In addition to the YAML role specification format updates, I changed an instance of the command module/touch with the copy module.

---

**Testing**

``` bash
$ cd examples
$ rm -rf roles/azavea.git roles/azavea.pip
$ vagrant destroy -f && vagrant up
```
