### PR TITLE
Feature/tnation/scons script

### DIFF
--- a/examples/roles.yml
+++ b/examples/roles.yml
@@ -1,4 +1,4 @@
 - name: azavea.pip
-  version: 0.1.1
+  version: 1.0.0
 - name: azavea.git
   version: 0.1.0

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -1,4 +1,9 @@
 ---
 - hosts: all
+
+  pre_tasks:
+    - name: "Update APT Cache"
+      apt: update_cache=true
+
   roles:
     - { role: "azavea.statsite" }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: Install SCons
   pip: name="SCons"
-       extra_args="--egg"
+       extra_args="--egg --install-option --standard-lib"
        state=present
 
 - name: Build Statsite


### PR DESCRIPTION
Ensures that the `SCons` python module is installed on the system path so that it can be imported during the `statsite` build process. See the "Install the built SCons files" section of the [SCons documentation](https://bitbucket.org/scons/scons).

Also, update the version of `ansible-pip` used in the example and ensure that the APT cache is up to date before running the role.

# Testing
See OpenTreeMap/otm-cloud#361

Fixes #6 

